### PR TITLE
Update Entity.php

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -21,7 +21,7 @@ abstract class Entity extends \TiSuit\Core\Root
      */
     protected function __getEntityName(): string
     {
-        return ($pos = strrpos(get_class($this), '\\')) ? substr(get_class($this), $pos + 1) : $pos;
+        return ($pos = strrpos(get_class($this), '\\')) ? substr(get_class($this), $pos + 1) : get_class($this);
     }
 
     /**


### PR DESCRIPTION
I'm not sure if it's the best way to return the name of the class in this way, but anyway it will resolve the issue with returning the integer instead of string. Its not critical and it can be reproduced only in case you decide to change the structure of the project.