### PR TITLE
Update Entity.php

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -126,9 +126,9 @@ abstract class Entity extends \TiSuit\Core\Root
         $errors = [];
         foreach ($this->getValidators()[$method] ?? [] as $field => $validator) {
             try {
-                $validator->assert($this->get($field));
+                $validator->setName($field)->assert($this->get($field));
             } catch (NestedValidationException $e) {
-                $errors[$field] = $e->getFullMessage();
+                $errors[$field] = $e->getMessages();
             }
         }
 


### PR DESCRIPTION
in error message instead of getting the value, its setting the field name, example: "null must be valid email" -> "email must be valid email", and also now is key with array of messages instead of key with string